### PR TITLE
Critical fix to allow sM.next_send to be null-able.

### DIFF
--- a/Factz/migrations/0048_auto_20151018_1138.py
+++ b/Factz/migrations/0048_auto_20151018_1138.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('Factz', '0047_custommessage_selected'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='sentmessage',
+            name='next_send',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+    ]

--- a/Factz/models.py
+++ b/Factz/models.py
@@ -281,7 +281,7 @@ class sentMessage(models.Model):
     message = models.ForeignKey(Message, null=True, blank=True, default=None, on_delete=models.PROTECT)
     custom_message = models.ForeignKey(customMessage, null=True, blank=True, default=None, on_delete=models.PROTECT)
     daily_send = models.ForeignKey(dailySend, null=True, blank=True, default=None, on_delete=models.PROTECT)
-    next_send = models.DateTimeField()
+    next_send = models.DateTimeField(null=True,blank=True)
     next_send_date = models.DateField()
     sent_time = models.DateTimeField(default=None, null=True, blank=True)
     attempted = models.IntegerField(default=0, choices=((0, "Not attempted"), (1, "Message attempted"), (2, "Completed")))


### PR DESCRIPTION
Needed this fix to allow get_or_create in dailySend to work.
